### PR TITLE
Remove logging.basicConfig from serial.py

### DIFF
--- a/meterbus/serial.py
+++ b/meterbus/serial.py
@@ -18,7 +18,6 @@ from .exceptions import (MBusFrameDecodeError, MBusFrameCRCError,
 from .defines import *
 import logging
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This line has to be removed because if I use logging.basicConfig(level=logging.DEBUG, [some more config]) in my main script and also want to use this library, it causes to overwrite the config with just logging.basicConfig(level=logging.INFO) which is obviously bad. I don't even use serial.