### PR TITLE
Fix flakiness

### DIFF
--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -13,6 +13,7 @@ from meterbus.exceptions import *
 
 class TestSequenceFunctions(unittest.TestCase):
     def setUp(self):
+        meterbus.debug(False)
         pass
 
     def test_debug_default_value(self):


### PR DESCRIPTION
A test inside [test_globals.py](https://github.com/ganehag/pyMeterBus/blob/master/tests/test_globals.py) was found to be flaky, i.e. test that both pass and fail despite no changes to the code or the tests itself.

Using the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin, when the tests were re-run more than once, the test `test_debug_default_value` was failing. Upon looking at the code, the reason was because the value of debug was not being reset back to False on a subsequent run. To fix this, I just added and extra call which initially sets the value of debug to False.

In general, flaky tests are a pain to fix with regards to locating the root of the actual problem, so it's a good idea to fix them when you detect them. I'm aware that the tests might not be re-run at all, but this change makes the entire module more robust and future-proof so it's just a small fix for you to consider.

To reproduce:

Install pytest-flakefinder by following the instructions [here](https://github.com/dropbox/pytest-flakefinder).
At root directory, run `python3 -m pytest --flake-finder`
After implementing the fix, all tests pass successfully, both with and without the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin being used.
