### PR TITLE
VIF(E): add support for enhancement extensions (M-Bus 8.4.5)

### DIFF
--- a/meterbus/core_objects.py
+++ b/meterbus/core_objects.py
@@ -55,6 +55,8 @@ class DataEncoding(Enum):
 
 
 class VIFUnit(Enum):
+    # REF: M-Bus, §8.4.4a
+
     ENERGY_WH = 0x07                # E000 0xxx
     ENERGY_J = 0x0F                 # E000 1xxx
     VOLUME = 0x17                   # E001 0xxx
@@ -96,6 +98,8 @@ class VIFUnit(Enum):
 
 
 class VIFUnitExt(Enum):
+    # REF: M-Bus, §8.4.4b
+
     # Currency Units
     CURRENCY_CREDIT = 0x03  # E000 00nn Credit of 10 nn-3 of the nominal ...
     CURRENCY_DEBIT = 0x07   # E000 01nn Debit of 10 nn-3 of the nominal ...
@@ -172,6 +176,44 @@ class VIFUnitExt(Enum):
 
 class VIFUnitSecExt(Enum):
     RELATIVE_HUMIDITY = 0x1A
+
+
+class VIFUnitEnhExt(Enum):
+    # REF: M-Bus, §8.4.5 ("enhancement of VIF's other than $FD")
+
+    # E00x xxxx Reserved
+    PER_SECOND = 0x20              # E010 0000 per second
+    PER_MINUTE = 0x21              # E010 0001 per minute
+    PER_HOUR = 0x22                # E010 0010 per hour
+    PER_DAY = 0x23                 # E010 0011 per day
+    PER_WEEK = 0x24                # E010 0100 per week
+    PER_MONTH = 0x25               # E010 0101 per month
+    PER_YEAR = 0x26                # E010 0110 per year
+    PER_REVOLUTION = 0x27          # E010 0111 per revolution / measurement
+    PER_INPUT_PULSE0 = 0x28        # E010 100p increment per input pulse on input channel #p
+    PER_INPUT_PULSE1 = 0x29
+    PER_OUTPUT_PULSE0 = 0x2A       # E010 101p increment per output pulse on output channel #p
+    PER_OUTPUT_PULSE1 = 0x2B
+    PER_LITER = 0x2C               # E010 1100 per liter
+    PER_M3 = 0x2D                  # E010 1101 per m3
+    PER_KG = 0x2E                  # E010 1110 per kg
+    PER_KELVIN = 0x2F              # E010 1111 per K (Kelvin)
+    PER_KWH = 0x30                 # E011 0000 per kWh
+    PER_GJ = 0x31                  # E011 0001 per GJ
+    PER_KW = 0x32                  # E011 0010 per kW
+    PER_KELVIN_LITER = 0x33        # E011 0011 per (K*l) (Kelvin*liter)
+    PER_VOLT = 0x34                # E011 0100 per V (Volt)
+    PER_AMPERE = 0x35              # E011 0101 per A (Ampere)
+    MULT_SEK = 0x36                # E011 0110 multiplied by sek
+    MULT_SEK_PER_VOLT = 0x37       # E011 0111 multiplied by sek / V
+    MULT_SEK_PER_AMPERE = 0x38     # E011 1000 multiplied by sek / A
+    START_DATE_TIME = 0x39         # E011 1001 start date(/time) of  
+    UNCORRECTED_UNIT = 0x3A        # E011 1010 VIF contains uncorrected unit instead of corrected unit
+    POSITIVE_ACCUMULATION = 0x3B   # E011 1011 Accumulation only if positive ACCUMULATIONs
+    NEGATIVE_ACCUMULATION = 0x3C   # E011 1100 Accumulation of abs value only if negative ACCUMULATIONs
+    # E011 1101 to # E011 1111 Reserved
+
+    UNKNOWN_ENHANCEMENT = 0x100
 
 
 class VIFTable(object):
@@ -799,6 +841,41 @@ class VIFTable(object):
         0x27D: (1.0e2,  MeasureUnit.W, "Cumul count max power"),
         0x27E: (1.0e3,  MeasureUnit.W, "Cumul count max power"),
         0x27F: (1.0e4,  MeasureUnit.W, "Cumul count max power")
+    }
+
+    # Additional VIFE-Code Extension table (following other primary VIF)
+    # See 8.4.5
+
+    enh = {
+        0x20: VIFUnitEnhExt.PER_SECOND,
+        0x21: VIFUnitEnhExt.PER_MINUTE,
+        0x22: VIFUnitEnhExt.PER_HOUR,
+        0x23: VIFUnitEnhExt.PER_DAY,
+        0x24: VIFUnitEnhExt.PER_WEEK,
+        0x25: VIFUnitEnhExt.PER_MONTH,
+        0x26: VIFUnitEnhExt.PER_YEAR,
+        0x27: VIFUnitEnhExt.PER_REVOLUTION,
+        0x28: VIFUnitEnhExt.PER_INPUT_PULSE0,
+        0x29: VIFUnitEnhExt.PER_INPUT_PULSE1,
+        0x2A: VIFUnitEnhExt.PER_OUTPUT_PULSE0,
+        0x2B: VIFUnitEnhExt.PER_OUTPUT_PULSE1,
+        0x2C: VIFUnitEnhExt.PER_LITER,
+        0x2D: VIFUnitEnhExt.PER_M3,
+        0x2E: VIFUnitEnhExt.PER_KG,
+        0x2F: VIFUnitEnhExt.PER_KELVIN,
+        0x30: VIFUnitEnhExt.PER_KWH,
+        0x31: VIFUnitEnhExt.PER_GJ,
+        0x32: VIFUnitEnhExt.PER_KW,
+        0x33: VIFUnitEnhExt.PER_KELVIN_LITER,
+        0x34: VIFUnitEnhExt.PER_VOLT,
+        0x35: VIFUnitEnhExt.PER_AMPERE,
+        0x36: VIFUnitEnhExt.MULT_SEK,
+        0x37: VIFUnitEnhExt.MULT_SEK_PER_VOLT,
+        0x38: VIFUnitEnhExt.MULT_SEK_PER_AMPERE,
+        0x39: VIFUnitEnhExt.START_DATE_TIME,
+        0x3A: VIFUnitEnhExt.UNCORRECTED_UNIT,
+        0x3B: VIFUnitEnhExt.POSITIVE_ACCUMULATION,
+        0x3C: VIFUnitEnhExt.NEGATIVE_ACCUMULATION,
     }
 
 

--- a/tests/test_variable_data_record.py
+++ b/tests/test_variable_data_record.py
@@ -18,7 +18,8 @@ class TestSequenceFunctions(unittest.TestCase):
                      "\xfc\x03\x48\x52\x25\x74\xb4\x16\x02\x65\xd0\x08\x22\x65" \
                      "\x70\x08\x12\x65\x23\x09\x01\x72\x18\x42\x65\xe4\x08\x82" \
                      "\x01\x65\xdd\x08\x0c\x78\x34\x08\x00\x54\x03\xfd\x0f\x00" \
-                     "\x00\x04\x1f\x5d\x16"
+                     "\x00\x04\x04\x83\x3b\x87\xd6\x12\x00\x04\x83\x3c\x87\xd6" \
+                     "\x12\x00\x1f\xc0\x16"
         self.frame2 = "\x68\xD8\xD8\x68\x08\x00\x72\x92\x03\x00\x64\x96\x15" \
                       "\x14\x31\x04\x00\x00\x00\x0C\x78\x92\x03\x00\x64\x0D" \
                       "\xFD\x0F\x05\x33\x2E\x36\x2E\x31\x0D\x7C\x03\x79\x65" \
@@ -50,19 +51,19 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_vif_mult_oxfc_0x78(self):
         t = meterbus.TelegramVariableDataRecord()
         t.vib.parts = [0xFC, 0x78]
-        mult, _, _ = t._parse_vifx()
+        mult, _, _, _ = t._parse_vifx()
         self.assertEqual(mult, 0.001)
 
     def test_vif_mult_oxfc_0x7B(self):
         t = meterbus.TelegramVariableDataRecord()
         t.vib.parts = [0xFC, 0x7B]
-        mult, _, _ = t._parse_vifx()
+        mult, _, _, _ = t._parse_vifx()
         self.assertEqual(mult, 1.0)
 
     def test_vif_mult_oxfc_0x7D(self):
         t = meterbus.TelegramVariableDataRecord()
         t.vib.parts = [0xFC, 0x7D]
-        mult, _, _ = t._parse_vifx()
+        mult, _, _, _ = t._parse_vifx()
         self.assertEqual(mult, 1.0)
 
     def test_parsed_value_invalid_data_len(self):
@@ -226,6 +227,30 @@ class TestSequenceFunctions(unittest.TestCase):
             "storage_number": 0,
         }
         frame_rec_dict = json.loads(self.frame.records[11].to_JSON())
+        self.assertEqual(frame_rec_dict, dict_record)
+
+    def test_json_record12(self):
+        dict_record = {
+            "value": 1234567,
+            "unit": "MeasureUnit.WH",
+            "type": "VIFUnit.ENERGY_WH",
+            "function": "FunctionType.INSTANTANEOUS_VALUE",
+            "storage_number": 0,
+            "unit_enh": "VIFUnitEnhExt.POSITIVE_ACCUMULATION",
+        }
+        frame_rec_dict = json.loads(self.frame.records[12].to_JSON())
+        self.assertEqual(frame_rec_dict, dict_record)
+
+    def test_json_record13(self):
+        dict_record = {
+            "value": 1234567,
+            "unit": "MeasureUnit.WH",
+            "type": "VIFUnit.ENERGY_WH",
+            "function": "FunctionType.INSTANTANEOUS_VALUE",
+            "storage_number": 0,
+            "unit_enh": "VIFUnitEnhExt.NEGATIVE_ACCUMULATION",
+        }
+        frame_rec_dict = json.loads(self.frame.records[13].to_JSON())
         self.assertEqual(frame_rec_dict, dict_record)
 
     def test_json_value_str(self):


### PR DESCRIPTION
Hello,
Thanks in advance for considering this MR and extension to pyMeterBus.
Best,
Cédric

<details>
<summary>Unit tests OK</summary>
<pre>
~/dev/upstream/pyMeterBus (HEAD -> VIFUnitEnhExt)
python -m unittest tests/test*.py
...........................................................................................................................INFO:meterbus.serial:RECV (001) 68
INFO:meterbus.serial:RECV (001) 03
INFO:meterbus.serial:RECV (001) 03
INFO:meterbus.serial:RECV (001) 68
INFO:meterbus.serial:RECV (001) 08
INFO:meterbus.serial:RECV (001) 0B
INFO:meterbus.serial:RECV (001) 72
INFO:meterbus.serial:RECV (001) 00
INFO:meterbus.serial:RECV (001) 16
.INFO:meterbus.serial:SEND (005) 10 40 00 40 16
.INFO:meterbus.serial:SEND (005) 10 5B 00 5B 16
....INFO:meterbus.serial:SEND (005) 10 7B 00 7B 16
INFO:meterbus.serial:SEND (005) 10 5B 00 5B 16
.INFO:meterbus.serial:SEND (005) 10 40 00 40 16
INFO:meterbus.serial:RECV (001) E5
.INFO:meterbus.serial:RECV (001) 68
INFO:meterbus.serial:RECV (001) 53
INFO:meterbus.serial:RECV (001) 53
INFO:meterbus.serial:RECV (001) 68
INFO:meterbus.serial:RECV (001) 08
INFO:meterbus.serial:RECV (001) 05
INFO:meterbus.serial:RECV (001) 72
INFO:meterbus.serial:RECV (001) 34
INFO:meterbus.serial:RECV (001) 08
.INFO:meterbus.serial:SEND (005) 10 5B 00 5B 16
.INFO:meterbus.serial:SEND (017) 68 0B 0B 68 73 FD 52 01 00 00 00 DA DA FA 1B 8C 16
INFO:meterbus.serial:RECV (001) E5
.INFO:meterbus.serial:SEND (005) 10 5B 00 5B 16
....................................................................................
----------------------------------------------------------------------
Ran 218 tests in 0.346s

OK

~/dev/upstream/pyMeterBus (HEAD -> VIFUnitEnhExt, genedis/VIFUnitEnhExt)
python -m unittest -v tests/test_variable_data_record.py
test_datafield_set (tests.test_variable_data_record.TestSequenceFunctions.test_datafield_set) ... ok
test_json_record0 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record0) ... ok
test_json_record1 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record1) ... ok
test_json_record10 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record10) ... ok
test_json_record11 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record11) ... ok
test_json_record12 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record12) ... ok
test_json_record13 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record13) ... ok
test_json_record2 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record2) ... ok
test_json_record4 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record4) ... ok
test_json_record5 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record5) ... ok
test_json_record6 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record6) ... ok
test_json_record7 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record7) ... ok
test_json_record8 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record8) ... ok
test_json_record9 (tests.test_variable_data_record.TestSequenceFunctions.test_json_record9) ... ok
test_json_value_str (tests.test_variable_data_record.TestSequenceFunctions.test_json_value_str) ... ok
test_more_records_follow_false (tests.test_variable_data_record.TestSequenceFunctions.test_more_records_follow_false) ... ok
test_more_records_follow_true (tests.test_variable_data_record.TestSequenceFunctions.test_more_records_follow_true) ... ok
test_parsed_value_invalid_data_len (tests.test_variable_data_record.TestSequenceFunctions.test_parsed_value_invalid_data_len) ... ok
test_verify_float_value (tests.test_variable_data_record.TestSequenceFunctions.test_verify_float_value) ... ok
test_verify_function (tests.test_variable_data_record.TestSequenceFunctions.test_verify_function) ... ok
test_verify_str_value (tests.test_variable_data_record.TestSequenceFunctions.test_verify_str_value) ... ok
test_verify_ustr_value (tests.test_variable_data_record.TestSequenceFunctions.test_verify_ustr_value) ... ok
test_vif_mult_oxfc_0x78 (tests.test_variable_data_record.TestSequenceFunctions.test_vif_mult_oxfc_0x78) ... ok
test_vif_mult_oxfc_0x7B (tests.test_variable_data_record.TestSequenceFunctions.test_vif_mult_oxfc_0x7B) ... ok
test_vif_mult_oxfc_0x7D (tests.test_variable_data_record.TestSequenceFunctions.test_vif_mult_oxfc_0x7D) ... ok

----------------------------------------------------------------------
Ran 25 tests in 0.014s

OK
</pre>
</details>