### PR TITLE
WIP: Use monkeytype to apply typehints

### DIFF
--- a/meterbus/core_objects.py
+++ b/meterbus/core_objects.py
@@ -1,5 +1,5 @@
 from enum import Enum
-
+from typing import Tuple, Dict, Union
 
 class MeasureUnit(Enum):
     KWH = "kWh"
@@ -219,7 +219,7 @@ class VIFUnitEnhExt(Enum):
 class VIFTable(object):
     # Primary VIFs (main table), range 0x00 - 0xFF
 
-    lut = {
+    lut: Dict[int, Tuple[float, Union[str, MeasureUnit], Union[str, VIFUnit, VIFUnitExt, VIFUnitSecExt]]] = {
         # E000 0nnn    Energy Wh (0.001Wh to 10000Wh)
         0x00: (1.0e-3, MeasureUnit.WH, VIFUnit.ENERGY_WH),
         0x01: (1.0e-2, MeasureUnit.WH, VIFUnit.ENERGY_WH),

--- a/meterbus/telegram_control.py
+++ b/meterbus/telegram_control.py
@@ -3,10 +3,11 @@ from .telegram_header import TelegramHeader
 from .exceptions import MBusFrameCRCError, MBusFrameDecodeError, MBusFrameEncodeError, FrameMismatch
 
 from .defines import *
+from typing import Iterator, List, Optional, Union
 
 class TelegramControl(object):
     @staticmethod
-    def parse(data):
+    def parse(data: Optional[List[int]]) -> "TelegramControl":
         if data is None:
             raise MBusFrameDecodeError("Data is None")
 
@@ -18,7 +19,7 @@ class TelegramControl(object):
 
         return TelegramControl(data)
 
-    def __init__(self, dbuf=None):
+    def __init__(self, dbuf: Optional[Union[str, bytes, List[int]]]=None) -> None:
         self._header = TelegramHeader()
         self._body = TelegramBody()
 
@@ -113,15 +114,15 @@ class TelegramControl(object):
     def body(self, value):
         self._body = value
 
-    def compute_crc(self):
+    def compute_crc(self) -> int:
         return (self.header.cField.parts[0] +
                 self.header.aField.parts[0] +
                 self.body.bodyHeader.ci_field.parts[0]) % 256
 
-    def check_crc(self):
+    def check_crc(self) -> bool:
         return self.compute_crc() == self.header.crcField.parts[0]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return (
             len(self.header.startField.parts) * 2 +
             len(self.header.lField.parts) * 2 +
@@ -132,7 +133,7 @@ class TelegramControl(object):
             len(self.header.stopField.parts)
         )
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         yield self.header.startField.parts[0]
         yield len(self.body.bodyHeader.ci_field.parts) + 2
         yield len(self.body.bodyHeader.ci_field.parts) + 2

--- a/meterbus/telegram_field.py
+++ b/meterbus/telegram_field.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Union
 
 class TelegramField(object):
     def __init__(self, parts: Optional[Union[int, List[int]]]=None) -> None:
-        self._parts = []
+        self._parts: List[int] = []
 
         if parts is not None:
             if isinstance(parts, str):

--- a/meterbus/telegram_field.py
+++ b/meterbus/telegram_field.py
@@ -3,10 +3,11 @@ from .core_objects import DateCalculator
 
 from builtins import (bytes, str, open, super, range,
                       zip, round, input, int, pow, object)
+from typing import List, Optional, Union
 
 
 class TelegramField(object):
-    def __init__(self, parts=None):
+    def __init__(self, parts: Optional[Union[int, List[int]]]=None) -> None:
         self._parts = []
 
         if parts is not None:
@@ -20,7 +21,7 @@ class TelegramField(object):
                 self.parts += [parts]
 
     @property
-    def decodeInt(self):
+    def decodeInt(self) -> int:
         int_data = self.parts
         value = 0
         neg = int_data[-1] & 0x80
@@ -40,7 +41,7 @@ class TelegramField(object):
         return value
 
     @property
-    def decodeBCD(self):
+    def decodeBCD(self) -> int:
         bcd_data = self.parts
         val = 0
 
@@ -64,7 +65,7 @@ class TelegramField(object):
         return struct.unpack('f', bytes(real_data))[0]
 
     @property
-    def decodeManufacturer(self):
+    def decodeManufacturer(self) -> str:
         m_id = self.decodeInt
         return "{0}{1}{2}".format(
             chr(((m_id >> 10) & 0x001F) + 64),
@@ -72,15 +73,15 @@ class TelegramField(object):
             chr(((m_id) & 0x001F) + 64))
 
     @property
-    def decodeASCII(self):
+    def decodeASCII(self) -> str:
         return "".join(map(chr, reversed(self.parts)))
 
     @property
-    def decodeRAW(self):
+    def decodeRAW(self) -> str:
         return " ".join(map(lambda x: "%02X" % x, self.parts))
 
     @property
-    def decodeDate(self):
+    def decodeDate(self) -> str:
         return DateCalculator.getDate(
             self.parts[0], self.parts[1], False)
 
@@ -144,8 +145,8 @@ class TelegramField(object):
         return " ".join(
             [hex(x).replace('0x', '').zfill(2) for x in self.parts])
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: slice) -> List[int]:
         return self.parts[key]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.parts)

--- a/meterbus/telegram_header.py
+++ b/meterbus/telegram_header.py
@@ -1,9 +1,10 @@
 import simplejson as json
 from .telegram_field import TelegramField
+from typing import Dict, List, Union
 
 
 class TelegramHeader(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self._startField = TelegramField([0x68])
         self._lField = TelegramField([0x00])
         self._cField = TelegramField()
@@ -15,11 +16,11 @@ class TelegramHeader(object):
         self._headerLengthCRCStop = 8
 
     @property
-    def headerLength(self):
+    def headerLength(self) -> int:
         return self._headerLength
 
     @property
-    def headerLengthCRCStop(self):
+    def headerLengthCRCStop(self) -> int:
         return self._headerLengthCRCStop
 
     @property
@@ -71,7 +72,7 @@ class TelegramHeader(object):
         self._stopField = TelegramField(value)
 
     @property
-    def interpreted(self):
+    def interpreted(self) -> Dict[str, str]:
         return {
             'start': hex(self.startField.parts[0]),
             'length': hex(self.lField.parts[0]),
@@ -81,7 +82,7 @@ class TelegramHeader(object):
             'stop': hex(self.stopField.parts[0])
         }
 
-    def load(self, hat):
+    def load(self, hat: Union[str, List[int]]) -> None:
         header = hat
         if isinstance(hat, str):
             header = list(map(ord, hat))
@@ -102,6 +103,6 @@ class TelegramHeader(object):
             self.crcField = header[-2]
             self.stopField = header[-1]
 
-    def to_JSON(self):
+    def to_JSON(self) -> str:
         return json.dumps(self.interpreted, sort_keys=False,
                           indent=4, use_decimal=True)

--- a/meterbus/telegram_short.py
+++ b/meterbus/telegram_short.py
@@ -1,11 +1,12 @@
 from .defines import *
 from .telegram_header import TelegramHeader
 from .exceptions import MBusFrameDecodeError, MBusFrameCRCError, FrameMismatch
+from typing import Iterator, List, Optional, Union
 
 
 class TelegramShort(object):
     @staticmethod
-    def parse(data):
+    def parse(data: Optional[List[int]]) -> "TelegramShort":
         if data is None:
             raise MBusFrameDecodeError("Data is None")
 
@@ -17,7 +18,7 @@ class TelegramShort(object):
 
         return TelegramShort(data)
 
-    def __init__(self, dbuf=None):
+    def __init__(self, dbuf: Optional[Union[str, bytes, List[int]]]=None) -> None:
         self._header = TelegramHeader()
         if dbuf is not None:
             tgr = dbuf
@@ -48,17 +49,17 @@ class TelegramShort(object):
     def header(self, value):
         self._header = value
 
-    def compute_crc(self):
+    def compute_crc(self) -> int:
         return (self.header.cField.parts[0] +
                 self.header.aField.parts[0]) % 256
 
-    def check_crc(self):
+    def check_crc(self) -> bool:
         return self.compute_crc() == self.header.crcField.parts[0]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return 0x05
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         yield self._header.startField.parts[0]
         yield self._header.cField.parts[0]
         yield self._header.aField.parts[0]

--- a/meterbus/telegram_variable_data_record.py
+++ b/meterbus/telegram_variable_data_record.py
@@ -10,13 +10,14 @@ from .value_information_block import ValueInformationBlock
 from .data_information_block import DataInformationBlock
 
 from .core_objects import VIFTable, VIFUnit, VIFUnitEnhExt, DataEncoding, MeasureUnit
+from typing import Any, Dict, Optional, Union
 
 
 class TelegramVariableDataRecord(object):
     UNIT_MULTIPLIER_MASK = 0x7F    # 0111 1111
     EXTENSION_BIT_MASK = 0x80      # 1000 0000
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.dib = DataInformationBlock()
         self.vib = ValueInformationBlock()
 
@@ -31,10 +32,10 @@ class TelegramVariableDataRecord(object):
         self._dataField = value
 
     @property
-    def more_records_follow(self):
+    def more_records_follow(self) -> bool:
         return self.dib.more_records_follow and self.dib.is_eoud
 
-    def _parse_vifx(self):
+    def _parse_vifx(self) -> Any:
         if len(self.vib.parts) == 0:
             return None, None, None, None
 
@@ -89,14 +90,14 @@ class TelegramVariableDataRecord(object):
         )
 
     @property
-    def unit(self):
+    def unit(self) -> Optional[str]:
         _, unit, _, _ = self._parse_vifx()
         if isinstance(unit, MeasureUnit):
             return unit.value
         return unit
 
     @property
-    def value(self):
+    def value(self) -> Union[str,     decimal.Decimal]:
         value = self.parsed_value
         if type(value) == str and all(ord(c) < 128 for c in value):
             value = str(value)
@@ -110,12 +111,12 @@ class TelegramVariableDataRecord(object):
         return value
 
     @property
-    def function(self):
+    def function(self) -> int:
         func = self.dib.function_type
         return func.value
 
     @property
-    def parsed_value(self):
+    def parsed_value(self) -> Optional[Union[str, int,     decimal.Decimal]]:
         mult, unit, _, _ = self._parse_vifx()
 
         length, enc = self.dib.length_encoding
@@ -165,7 +166,7 @@ class TelegramVariableDataRecord(object):
         }.get(enc, lambda: None)()
 
     @property
-    def interpreted(self):
+    def interpreted(self) -> Dict[str, Union[    decimal.Decimal, str, int]]:
         _, unit, typ, unit_enh = self._parse_vifx()
         storage_number, tariff, device = self.dib.parse_dife()
 
@@ -203,6 +204,6 @@ class TelegramVariableDataRecord(object):
 
         return record
 
-    def to_JSON(self):
+    def to_JSON(self) -> str:
         return json.dumps(self.interpreted, sort_keys=True,
                           indent=4, use_decimal=True)

--- a/meterbus/value_information_block.py
+++ b/meterbus/value_information_block.py
@@ -1,11 +1,12 @@
 from .telegram_field import TelegramField
+from typing import List, Optional
 
 
 class ValueInformationBlock(TelegramField):
     EXTENSION_BIT_MASK = 0x80  # 1000 0000
     WITHOUT_EXTENSION_BIT_MASK = 0x7F  # 0111 1111
 
-    def __init__(self, parts=None):
+    def __init__(self, parts: Optional[List[int]]=None) -> None:
         super(ValueInformationBlock, self).__init__(parts)
         self._custom_vif = TelegramField()
 
@@ -18,21 +19,21 @@ class ValueInformationBlock(TelegramField):
         self._custom_vif = value
 
     @property
-    def has_extension_bit(self):
+    def has_extension_bit(self) -> bool:
         try:
             return (self.parts[-1] & self.EXTENSION_BIT_MASK) > 0
         except IndexError:
             return False
 
     @property
-    def without_extension_bit(self):
+    def without_extension_bit(self) -> bool:
         try:
             return (self.parts[0] & self.WITHOUT_EXTENSION_BIT_MASK) == 0x7C
         except IndexError:
             return False
 
     @property
-    def has_lvar_bit(self):
+    def has_lvar_bit(self) -> bool:
         """returns true if first VIFE has LVAR set"""
         try:
             return (self.parts[1] & self.EXTENSION_BIT_MASK) > 0

--- a/meterbus/wtelegram_snd_nr.py
+++ b/meterbus/wtelegram_snd_nr.py
@@ -6,11 +6,12 @@ import simplejson as json
 from .wtelegram_header import WTelegramHeader
 from .wtelegram_body import WTelegramFrame
 from .exceptions import MBusFrameDecodeError, MBusFrameCRCError, FrameMismatch
+from typing import List
 
 
 class WTelegramSndNr(WTelegramFrame):
     @staticmethod
-    def parse(data):
+    def parse(data: List[int]):
         try:
             if data[1] != 0x44:  # SND-NR
                 raise FrameMismatch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,15 @@ exclude = ["tests", "examples"]
 
 [tool.setuptools.dynamic]
 version = { attr = "meterbus.__version__" }
+
+#
+# MPY tuning - this command should succeed: mypy -p meterbus
+#
+[[tool.mypy.overrides]]
+module = ["simplejson.*","Crypto.Cipher.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["yaml.*", "serial.*"]
+follow_untyped_imports = true
+


### PR DESCRIPTION
# Adding typehints

I saw this issue https://github.com/ganehag/pyMeterBus/issues/30 and tried to add type hints.

This is how far I got - now it is time to get feedback.

## What I did:

```bash
pytest tests --monkeytype-output=monkeytype.sqlite3
monkeytype run example_mbus.py
```

This way I collected runtime data from the test folder and from `example_mbus.py` running agains real meters.

Then I applied the typehints `monkeytype apply meterbus.zzz`.

The result is here [WIP: Applies types hints using monkeytype](https://github.com/ganehag/pyMeterBus/commit/a4677b961750dcf9fa81eaecb52beffb299e5f19).

## The easy typehints

About 60% of the typehints are simple and make sense.

## The complex typehints

Then I continued manually starting to resolve the `Any` type hints.
For example:
`def _parse_vifx(self) -> Any:`
which I manually resolved to:
`def _parse_vifx(self) -> Tuple[Union[None, int, float], Union[None, str, MeasureUnit], Union[None, str, VIFUnit, VIFUnitExt, VIFUnitSecExt], Union[None, VIFUnitEnhExt]]:`

Another complex structure is:
Before:
```python
lut = {
        # E000 0nnn    Energy Wh (0.001Wh to 10000Wh)
        0x00: (1.0e-3, MeasureUnit.WH, VIFUnit.ENERGY_WH),
```
and with the typehints resolved:
```python
lut: Dict[int, Tuple[float, Union[str, MeasureUnit], Union[str, VIFUnit, VIFUnitExt, VIFUnitSecExt]]] = {
        # E000 0nnn    Energy Wh (0.001Wh to 10000Wh)
        0x00: (1.0e-3, MeasureUnit.WH, VIFUnit.ENERGY_WH),
```

These changes are here: https://github.com/hmaerki/fork_pyMeterBus/commit/d6984ab83822f47c275f005f3aa2d8f4e398449c

## How to continue?

* First of all: Why bother? The code works also without type hints and there are many tests.
* The benefit of adding typehints is
  * Internally: That it will be easier to maintain and understand the code.
  * Externally: The library is easier to use.

If typehints are really wanted, I see several work packages:
* A) Add the easy typehints (60% of what monkeytype found).
* B) Add typehints specially for the API (meterbus/__init__.py, meterbus/serial.py)
* C) Get rid of decimal.Decimal in favor of float.
* D) Rething the types in `core_objects`. There are many enumerations and there datatypes spread in the whole package. There might be ways to hide all the different datatypes.
* E) `def _parse_vifx()` returns a tuple of four values (`Tuple[Union[None, int, float], Union[None, str, MeasureUnit], Union[None, str, VIFUnit, VIFUnitExt, VIFUnitSecExt], Union[None, VIFUnitEnhExt]]:`). There might be a cleaner way to do that.

My proposal would be to go for A) and B).