### PR TITLE
Do not break logging.basicConfig in other applications

### DIFF
--- a/meterbus/serial.py
+++ b/meterbus/serial.py
@@ -18,8 +18,8 @@ from .exceptions import (MBusFrameDecodeError, MBusFrameCRCError,
 from .defines import *
 import logging
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def serial_send(ser, data=None, read_echo=False):


### PR DESCRIPTION
The global call of logging.basicConfig breaks the configuration for all other applications, that import meterbus and call logging.basicConfig after that. To enable INFO logging, it is enough to set the level of the derived logger.